### PR TITLE
Add 'required' attribute to select form

### DIFF
--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -128,7 +128,7 @@ return {
 
           form_start = form_start .. "<div class=\"form-group\">\n"
           form_start = form_start .. "<label for = \"" .. id .. "\" class=\"form-label mt-4\">" .. label .. "</label>\n"
-          form_start = form_start .. "<select id= \"" .. id .. "\" size = \"" .. size .. "\" " .. multiple .. " class=\"form-select\">\n"
+          form_start = form_start .. "<select id= \"" .. id .. "\" size = \"" .. size .. "\" " .. multiple .. " " .. required .. " class=\"form-select\">\n"
           
           for v = 1,#field.values do
             local value = field.values[v]


### PR DESCRIPTION
The select form does not respect the 'required' field.
This PR adds the missing attribute.

Here is a MWE:
```
---
title: "Require selection"
format: html

form:
  id: mwe
  submit: "Print"
  action: "javascript:window.print()"
  fields:
  - name: Select-input
    type: select
    id: selectid
    label: "Please select"
    required: true
    size: 1
    values:
    - text: ' '
      value:
    - text: Foo
      value: 1
    - text: Bar
      value: 2
---

{{< form >}}
```

