### PR TITLE
Control method (GET vs POST) (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You define a form using the metadata in the document header, as follows:
 form:
   action: "/action.js"
   submit: "Submit Now!"
+  method: "GET"
   fields:
   - name: "A Text Field"
   - type: "text"

--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -32,10 +32,17 @@ return {
     if not isEmpty(meta["form.id"]) then
       form_id = pandoc.utils.stringify(meta["form.id"])
     end
+    
+    -- If the user passes a method, use it, otherwise use GET   
+    if not isEmpty(meta["form.method"]) then
+      method = pandoc.utils.stringify(meta["form.method"])
+    else
+      method = "GET"
+    end
 
     -- These are the form items
     -- action (form.action) describes the handler function for the form submit
-    local form_start = "<div id = \"" .. formid .. "-div\" class = \"form-wrapper\">\n <form id = \"" .. formid .. "\" action = \"" .. action .. "\">\n"
+    local form_start = "<div id = \"" .. formid .. "-div\" class = \"form-wrapper\">\n <form id = \"" .. formid .. "\" action = \"" .. action .. "\" method = \"" .. method .. "\">\n"
     local form_end = "</form></div>\n"
 
     -- Fields for the Form --

--- a/example.qmd
+++ b/example.qmd
@@ -10,6 +10,7 @@ form:
   id: MyFormID
   submit: "Submit"
   action: "javascript:submit()"
+  method: GET
   fields:
   - text: "This is a form spacer"
   - name: Text1
@@ -92,9 +93,10 @@ The form elements are:
 | Key     | Purpose     | Values | Required? | 
 |---------|------------|---------|--------|
 | `action`| path to action | `filepath` | Required |
+| `method`| HTTP method used for form submission (GET or POST) | `string` | Optional (Default: `GET`) |
 | `submit`| text for submit button | `string` | Optional (Default: `Submit`) |
 | `fields`| list of fields | `...` | `fields` | Required |
-| `id` | an id for the form | `string` | Option (Default: `form`) | 
+| `id` | an id for the form | `string` | Optional (Default: `form`) | 
 
 
 This is specified as follows:
@@ -103,11 +105,13 @@ This is specified as follows:
 ```yaml
 form:
   action: "pathto/action/file.js"
+  method: GET
   submit: "Submit Form"
   id: FormID
   fields:
   - ...
 ```
+
 ## Form Fields
 
 The `fields` element is a list of fields, as outlined below.  All inputs are strings, unless mentioned:


### PR DESCRIPTION
This adds support for a `method` YAML key where users can specify GET or POST, generating HTML like this:

```yaml
form:
  ...
  method: GET
  ...
```

↓

```html
<form id="form" action="javascript:submit()" method="GET">
...
</form>
```

and

```yaml
form:
  ...
  method: POST
  ...
```

↓

```html
<form id="form" action="javascript:submit()" method="POST">
...
</form>
```