### PR TITLE
fix(forms): Correct label class in form fields

### DIFF
--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -98,7 +98,7 @@ return {
           end
           
           form_start = form_start .. "<div class=\"form-group\">\n"
-          form_start = form_start .. "<label for =\"" .. id .. "\">" .. label .. "</label class = \"form-label mt-4\">\n"
+          form_start = form_start .. "<label for =\"" .. id .. "\" class = \"form-label mt-4\">" .. label .. "</label>\n"
           form_start = form_start .. "<textarea name =\"" .. name .. "\" id = \"" .. id .. "\" rows = \"" .. rows .. "\" cols =\"" .. cols .."\" class = \"form-control\"></textarea>\n"
           form_start = form_start .. "</div>\n"
         
@@ -166,7 +166,7 @@ return {
 
           form_start = form_start .. "<div class=\"form-group\">\n"
           form_start = form_start .. "<fieldset class=\"form-group\">\n"
-          form_start = form_start .. "<p class = \"form-label\">" .. label .. "</p>\n"
+          form_start = form_start .. "<p class = \"form-label mt-4\">" .. label .. "</p>\n"
           for v = 1, #field.values do
 
             local value = field.values[v]


### PR DESCRIPTION
This fixes vertical intervals for some form labels. 

Before:

<img width="843" height="861" alt="image" src="https://github.com/user-attachments/assets/5fd52159-86e8-4d19-afa0-ef7076f4917c" />

After: 

<img width="908" height="1016" alt="image" src="https://github.com/user-attachments/assets/db55b179-a95f-439d-b022-cd3e3cb68d3b" />
