### PR TITLE
fix(forms): Correct email input name attribute in form fields and add autocomplete attribute

### DIFF
--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -106,7 +106,7 @@ return {
         -- Handle email address inputs
           form_start = form_start .. "<div class=\"form-group\">\n"
           form_start = form_start .. "<label for=\"" .. id .. "\" class=\"form-label mt-4\">" .. label .. "</label>\n"
-          form_start = form_start .. "<input type=\"email\" id=\"" .. id .. "\" name=\"" .. name .. "\" class=\"form-control\" " .. required .. ">\n"
+          form_start = form_start .. "<input type=\"email\" id=\"" .. id .. "\" name=\"" .. name .. "\" class=\"form-control\" autocomplete=\"on\" " .. required .. ">\n"
           form_start = form_start .. "</div>\n"
 
         elseif type == "file" then

--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -135,7 +135,7 @@ return {
 
           form_start = form_start .. "<div class=\"form-group\">\n"
           form_start = form_start .. "<label for = \"" .. id .. "\" class=\"form-label mt-4\">" .. label .. "</label>\n"
-          form_start = form_start .. "<select id= \"" .. id .. "\" size = \"" .. size .. "\" " .. multiple .. " " .. required .. " class=\"form-select\">\n"
+          form_start = form_start .. "<select id= \"" .. id .. "\" name=\"" .. name .. "\" size = \"" .. size .. "\" " .. multiple .. " " .. required .. " class=\"form-select\">\n"
           
           for v = 1,#field.values do
             local value = field.values[v]

--- a/_extensions/forms/forms.lua
+++ b/_extensions/forms/forms.lua
@@ -106,7 +106,7 @@ return {
         -- Handle email address inputs
           form_start = form_start .. "<div class=\"form-group\">\n"
           form_start = form_start .. "<label for=\"" .. id .. "\" class=\"form-label mt-4\">" .. label .. "</label>\n"
-          form_start = form_start .. "<input type=\"email\" id=\"" .. id .. "\" name=\"" .. "\" class=\"form-control\" " .. required .. ">\n"
+          form_start = form_start .. "<input type=\"email\" id=\"" .. id .. "\" name=\"" .. name .. "\" class=\"form-control\" " .. required .. ">\n"
           form_start = form_start .. "</div>\n"
 
         elseif type == "file" then


### PR DESCRIPTION
This 1) fixes the missing `name` attribute in the form fields of types "email" and "select"; 2) adds `autocomplete="on"` attribute to the "email" field to allow user agent to pre-fill this field.