### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/forms/_schema.yml
+++ b/_extensions/forms/_schema.yml
@@ -1,0 +1,30 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+shortcodes:
+  form:
+    description: Render an HTML form from document metadata.
+
+options:
+  form:
+    type: object
+    description: Form definition metadata consumed by the form shortcode.
+    properties:
+      action:
+        type: string
+        description: Form submit endpoint URL.
+      submit:
+        type: string
+        description: Submit button text.
+      method:
+        type: string
+        enum: [GET, POST]
+        enum-case-insensitive: true
+        description: HTTP method used for form submission.
+      id:
+        type: string
+        description: HTML id used for the generated form element.
+      fields:
+        type: array
+        description: List of field definitions rendered in order.
+        items:
+          type: object

--- a/_extensions/forms/_snippets.json
+++ b/_extensions/forms/_snippets.json
@@ -1,0 +1,41 @@
+{
+  "Forms metadata setup": {
+    "prefix": "metadata",
+    "body": [
+      "filters:",
+      "  - jlgraves-ubc/forms",
+      "form:",
+      "  action: \"${1:/action.js}\"",
+      "  submit: \"${2:Submit Now!}\"",
+      "  method: \"${3:GET}\"",
+      "  fields:",
+      "    - name: \"${4:A Text Field}\"",
+      "      type: \"text\"",
+      "      id: \"${5:textfield1}\"",
+      "      label: \"${6:Your label}\""
+    ],
+    "description": "Insert base metadata for a form definition."
+  },
+  "Form shortcode": {
+    "prefix": "shortcode",
+    "body": [
+      "{{< form >}}"
+    ],
+    "description": "Insert the form shortcode at the render location."
+  },
+  "Form select field": {
+    "prefix": "select",
+    "body": [
+      "- name: \"${1:Choice}\"",
+      "  type: \"select\"",
+      "  id: \"${2:choice1}\"",
+      "  label: \"${3:Choose one}\"",
+      "  values:",
+      "    - text: \"${4:High}\"",
+      "      value: \"${5:hi}\"",
+      "    - text: \"${6:Low}\"",
+      "      value: \"${7:lo}\""
+    ],
+    "description": "Insert a select field entry for form.fields."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/forms/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/forms/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
